### PR TITLE
fix termination condition in for loop

### DIFF
--- a/MA_LIO/src/laserMapping.cpp
+++ b/MA_LIO/src/laserMapping.cpp
@@ -1025,12 +1025,12 @@ int main(int argc, char **argv)
             {
                 if (num == 0)
                 {
-                    for (int i = 0; i < kf.lidar_uncertainty[num].size() - 1; i++)
+                    for (int i = 0; i < (int)kf.lidar_uncertainty[num].size() - 1; i++)
                         pose_unc[num].push_back(kf.lidar_uncertainty[num][i]);
                 }
                 else
                 {
-                    for (int i = 0; i < kf.lidar_uncertainty[num].size() - 1; i++)
+                    for (int i = 0; i < (int)kf.lidar_uncertainty[num].size() - 1; i++)
                     {
                         compoundPoseWithCov(extrinsic[num], extrinsic[num].cov_, kf.lidar_uncertainty[num][i], kf.lidar_uncertainty[num][i].cov_, pose_point, pose_point.cov_, 2);
                         compoundPoseWithCov(kf.temporal_comp[num - 1], kf.temporal_comp[num - 1].cov_, pose_point, pose_point.cov_, pose_point, pose_point.cov_, 2);


### PR DESCRIPTION
**size() method return value with type size_t, which is an unsigned type.** When kf.lidar_uncertainty[num].size() == 0, kf.lidar_uncertainty[num].size() - 1 overflows, leading this expression to a very large number (e.g. 2^64-1). This might make the loop executes wrongly. A forced typecasting will fix this problem.